### PR TITLE
Fix invoice lines missing in document details

### DIFF
--- a/src/routes/documents/documents.service.ts
+++ b/src/routes/documents/documents.service.ts
@@ -52,6 +52,17 @@ import type {
 import { getSignatureParams } from "src/utils/signature";
 import { MyInvoisError } from "src/utils/error-handler";
 
+function normalizeInvoiceLines(document: any) {
+  if (!document?.Invoice) return;
+  const invoice = document.Invoice;
+  if (invoice.invoiceLines) return;
+  const lines =
+    invoice["cac:InvoiceLine"] ?? invoice["InvoiceLine"] ?? invoice.cacInvoiceLine;
+  if (lines) {
+    invoice.invoiceLines = lines;
+  }
+}
+
 export async function getRecentDocuments(
   query: GetRecentDocumentsRequestQuery
 ) {
@@ -96,6 +107,9 @@ export async function getDocumentDetails(
       documentId,
       taxpayerTIN // Pass taxpayerTIN if provided, client method should handle undefined
     );
+    if (documentDetails && typeof documentDetails === "object") {
+      normalizeInvoiceLines((documentDetails as any).document);
+    }
     return documentDetails;
   } catch (error) {
     const action = taxpayerTIN

--- a/src/routes/documents/documents.service.ts
+++ b/src/routes/documents/documents.service.ts
@@ -55,11 +55,20 @@ import { MyInvoisError } from "src/utils/error-handler";
 function normalizeInvoiceLines(document: any) {
   if (!document?.Invoice) return;
   const invoice = document.Invoice;
-  if (invoice.invoiceLines) return;
+
   const lines =
-    invoice["cac:InvoiceLine"] ?? invoice["InvoiceLine"] ?? invoice.cacInvoiceLine;
+    invoice["cac:InvoiceLine"] ??
+    invoice.InvoiceLine ??
+    invoice.invoiceLines ??
+    invoice.cacInvoiceLine;
+
   if (lines) {
-    invoice.invoiceLines = lines;
+    if (!invoice["cac:InvoiceLine"]) {
+      invoice["cac:InvoiceLine"] = lines;
+    }
+    if (!invoice.invoiceLines) {
+      invoice.invoiceLines = lines;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure `getDocumentDetails` normalizes invoice line data

## Testing
- `bun run lint` *(fails: jiti missing)*
- `bun run test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860be09a5d48330921fc2e806af58e7