### PR TITLE
Add get document endpoint

### DIFF
--- a/src/routes/documents/documents.controller.ts
+++ b/src/routes/documents/documents.controller.ts
@@ -5,6 +5,7 @@ import {
   cancelDocument,
   rejectDocument,
   searchDocuments,
+  getDocument,
   getDocumentDetails,
   submitCreditNotes,
   submitDebitNotes,
@@ -40,6 +41,8 @@ import {
   SubmitSelfBilledInvoiceDocumentsQueryScheme,
   SubmitSelfBilledRefundNoteDocumentsBodyScheme,
   SubmitSelfBilledRefundNoteDocumentsQueryScheme,
+  GetDocumentRequestParamsSchema,
+  GetDocumentRequestQuerySchema,
 } from "src/schemes";
 
 export const documentsController = (app: Elysia) => {
@@ -98,6 +101,20 @@ export const documentsController = (app: Elysia) => {
           },
           params: RejectDocumentRequestParamsSchema,
           query: RejectDocumentRequestQuerySchema,
+        }
+      )
+      .get(
+        "/:id/raw",
+        async ({ params, query }) => {
+          return await getDocument(params, query);
+        },
+        {
+          detail: {
+            summary: "Get Document",
+            description: `Retrieve the raw document payload from MyInvois.`,
+          },
+          params: GetDocumentRequestParamsSchema,
+          query: GetDocumentRequestQuerySchema,
         }
       )
       .get(

--- a/src/routes/documents/documents.service.ts
+++ b/src/routes/documents/documents.service.ts
@@ -48,6 +48,8 @@ import type {
   SubmitSelfBilledInvoiceDocumentsQuery,
   SubmitSelfBilledRefundNoteDocumentsBody,
   SubmitSelfBilledRefundNoteDocumentsQuery,
+  GetDocumentRequestParams,
+  GetDocumentRequestQuery,
 } from "src/schemes";
 import { getSignatureParams } from "src/utils/signature";
 import { MyInvoisError } from "src/utils/error-handler";
@@ -101,6 +103,34 @@ export async function getDocumentDetails(
     const action = taxpayerTIN
       ? `fetching document details for ID ${documentId} for TIN ${taxpayerTIN}`
       : `fetching document details for ID ${documentId} as taxpayer`;
+    throw new MyInvoisError(`Failed during ${action}`, error);
+  }
+}
+
+export async function getDocument(
+  params: GetDocumentRequestParams,
+  query: GetDocumentRequestQuery
+) {
+  const client = new MyInvoisClient(
+    CONFIG.clientId,
+    CONFIG.clientSecret,
+    CONFIG.env,
+    redisInstance
+  );
+
+  const documentId = params.id;
+  const taxpayerTIN = query.taxpayerTIN;
+
+  try {
+    const document = await client.documents.getDocumentByUuid(
+      documentId,
+      taxpayerTIN
+    );
+    return document;
+  } catch (error) {
+    const action = taxpayerTIN
+      ? `fetching document ${documentId} for TIN ${taxpayerTIN}`
+      : `fetching document ${documentId} as taxpayer`;
     throw new MyInvoisError(`Failed during ${action}`, error);
   }
 }

--- a/src/schemes/documents/get.schema.ts
+++ b/src/schemes/documents/get.schema.ts
@@ -1,0 +1,15 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { TaxpayerTINScheme } from "../common";
+
+export const GetDocumentRequestParamsSchema = Type.Object({
+  id: Type.String({
+    description: "Unique ID of the document to retrieve.",
+    examples: ["JA206PVZ6BYQ3547TZTEARWJ10"],
+  }),
+});
+
+export type GetDocumentRequestParams = Static<typeof GetDocumentRequestParamsSchema>;
+
+export const GetDocumentRequestQuerySchema = TaxpayerTINScheme;
+
+export type GetDocumentRequestQuery = Static<typeof GetDocumentRequestQuerySchema>;

--- a/src/schemes/documents/index.ts
+++ b/src/schemes/documents/index.ts
@@ -11,3 +11,4 @@ export * from "./self-billed-invoice.schema";
 export * from "./self-billed-credit-note.schema";
 export * from "./self-billed-debit-note.schema";
 export * from "./self-billed-refund-note.schema";
+export * from "./get.schema";


### PR DESCRIPTION
## Summary
- add schema for get document request
- export new schema
- implement getDocument service handler
- add `/documents/:id/raw` endpoint

## Testing
- `bun run lint` *(fails: jiti missing)*
- `bun run test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686209de3df48330b303e93557594d70