### PR TITLE
Add dynamic credential support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Use this gateway to easily submit invoices, credit notes, or debit notes from an
 - **Document Signing:** Manages the document signing process with flexible configuration.
 - **Optional Redis Caching:** Improves performance and reliability by caching responses.
 - **Developer-Friendly API Docs:** Interactive API documentation available via Swagger UI.
+- **Multi-User Credentials:** Override the default client credentials per request using `X-CLIENT-ID` and `X-CLIENT-SECRET` headers.
+- **Health Endpoint:** Simple `/health` route for uptime monitoring.
 
 The API documentation (Swagger UI) is available at `/docs/api` when the application is running.
 
@@ -55,6 +57,8 @@ Create a `.env` file in the root of the project (`myinvois-gateway/.env`) and ad
 ```env
 CLIENT_ID=your_client_id_here
 CLIENT_SECRET=your_client_secret_here
+# Optionally override these per request using headers:
+# X-CLIENT-ID and X-CLIENT-SECRET
 # GATEWAY_API_KEY=your_gateway_api_key_here # Optional
 # REDIS_URL=redis://localhost:6379 # Optional
 
@@ -83,6 +87,15 @@ CLIENT_SECRET=your_client_secret_here
 ```
 
 This `.env` file will be automatically used by `bun run dev`, when running the compiled binary locally (if your application loads it, typically via a library like `dotenv` which Bun might handle implicitly for `process.env`), and by Docker Compose if it's in the same directory.
+
+### Dynamic Credentials via Headers
+
+You can specify MyInvois credentials per request by including the following headers:
+
+- `X-CLIENT-ID`
+- `X-CLIENT-SECRET`
+
+If these headers are provided, they override the `CLIENT_ID` and `CLIENT_SECRET` values from the environment for that request. Both headers must be supplied together.
 
 ## Document Signing Configuration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,19 +73,30 @@ Use this gateway to easily submit invoices, credit notes, or debit notes from an
             { name: "Documents", description: "Documents endpoints" },
             { name: "Submissions", description: "Submissions endpoints" },
             { name: "Taxpayers", description: "Taxpayers endpoints" },
+            { name: "Health", description: "Health endpoints" },
           ],
           components: {
-            ...(GATEWAY_API_KEY
-              ? {
-                  securitySchemes: {
+            securitySchemes: {
+              ...(GATEWAY_API_KEY
+                ? {
                     apiKeyAuth: {
                       type: "apiKey",
                       name: "X-API-KEY",
                       in: "header",
                     },
-                  },
-                }
-              : {}),
+                  }
+                : {}),
+              clientId: {
+                type: "apiKey",
+                name: "X-CLIENT-ID",
+                in: "header",
+              },
+              clientSecret: {
+                type: "apiKey",
+                name: "X-CLIENT-SECRET",
+                in: "header",
+              },
+            },
           },
         },
         swaggerOptions: {
@@ -136,6 +147,12 @@ Use this gateway to easily submit invoices, credit notes, or debit notes from an
   controllers.forEach((controller: any) => {
     app.use(controller);
   });
+
+  app.get(
+    "/health",
+    () => ({ status: "ok" }),
+    { detail: { tags: ["Health"], summary: "Health Check" } }
+  );
 
   app.use(cors());
   app.listen(CONFIG.port);

--- a/src/routes/documents/documents.controller.ts
+++ b/src/routes/documents/documents.controller.ts
@@ -55,8 +55,8 @@ export const documentsController = (app: Elysia) => {
       })
       .get(
         "/",
-        ({ query }) => {
-          return getRecentDocuments(query);
+        ({ query, request }) => {
+          return getRecentDocuments(query, request.headers);
         },
         {
           detail: {
@@ -73,8 +73,8 @@ export const documentsController = (app: Elysia) => {
 
       .put(
         "/:id/cancel",
-        ({ params, query }) => {
-          return cancelDocument(params, query);
+        ({ params, query, request }) => {
+          return cancelDocument(params, query, request.headers);
         },
         {
           detail: {
@@ -89,8 +89,8 @@ export const documentsController = (app: Elysia) => {
       )
       .put(
         "/:id/reject",
-        ({ params, query }) => {
-          return rejectDocument(params, query);
+        ({ params, query, request }) => {
+          return rejectDocument(params, query, request.headers);
         },
         {
           detail: {
@@ -105,8 +105,8 @@ export const documentsController = (app: Elysia) => {
       )
       .get(
         "/:id/raw",
-        async ({ params, query }) => {
-          return await getDocument(params, query);
+        async ({ params, query, request }) => {
+          return await getDocument(params, query, request.headers);
         },
         {
           detail: {
@@ -119,8 +119,8 @@ export const documentsController = (app: Elysia) => {
       )
       .get(
         "/:id",
-        async ({ params, query }) => {
-          return await getDocumentDetails(params, query);
+        async ({ params, query, request }) => {
+          return await getDocumentDetails(params, query, request.headers);
         },
         {
           detail: {
@@ -137,8 +137,8 @@ export const documentsController = (app: Elysia) => {
       )
       .put(
         "search",
-        ({ query }) => {
-          return searchDocuments(query); // Call searchDocuments service
+        ({ query, request }) => {
+          return searchDocuments(query, request.headers); // Call searchDocuments service
         },
         {
           detail: {
@@ -153,8 +153,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/invoice",
-        ({ query, body }) => {
-          return submitInvoices(query, body);
+        ({ query, body, request }) => {
+          return submitInvoices(query, body, request.headers);
         },
         {
           detail: {
@@ -168,8 +168,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/credit-note",
-        ({ query, body }) => {
-          return submitCreditNotes(query, body);
+        ({ query, body, request }) => {
+          return submitCreditNotes(query, body, request.headers);
         },
         {
           detail: {
@@ -183,8 +183,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/debit-note",
-        ({ query, body }) => {
-          return submitDebitNotes(query, body);
+        ({ query, body, request }) => {
+          return submitDebitNotes(query, body, request.headers);
         },
         {
           detail: {
@@ -198,8 +198,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/refund-note",
-        ({ query, body }) => {
-          return submitRefundNotes(query, body);
+        ({ query, body, request }) => {
+          return submitRefundNotes(query, body, request.headers);
         },
         {
           detail: {
@@ -213,8 +213,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/self-billed-invoice",
-        ({ query, body }) => {
-          return submitSelfBilledInvoices(query, body);
+        ({ query, body, request }) => {
+          return submitSelfBilledInvoices(query, body, request.headers);
         },
         {
           detail: {
@@ -228,8 +228,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/self-billed-credit-note",
-        ({ query, body }) => {
-          return submitSelfBilledCreditNotes(query, body);
+        ({ query, body, request }) => {
+          return submitSelfBilledCreditNotes(query, body, request.headers);
         },
         {
           detail: {
@@ -243,8 +243,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/self-billed-debit-note",
-        ({ query, body }) => {
-          return submitSelfBilledDebitNotes(query, body);
+        ({ query, body, request }) => {
+          return submitSelfBilledDebitNotes(query, body, request.headers);
         },
         {
           detail: {
@@ -258,8 +258,8 @@ export const documentsController = (app: Elysia) => {
       )
       .post(
         "submit/self-billed-refund-note",
-        ({ query, body }) => {
-          return submitSelfBilledRefundNotes(query, body);
+        ({ query, body, request }) => {
+          return submitSelfBilledRefundNotes(query, body, request.headers);
         },
         {
           detail: {

--- a/src/routes/documents/documents.service.ts
+++ b/src/routes/documents/documents.service.ts
@@ -23,6 +23,7 @@ import {
   createDocumentSubmissionItemFromSelfBilledRefundNote,
 } from "myinvois-client";
 import { redisInstance } from "src/redis"; // Path to your gateway's Redis client instance
+import { createClient } from "src/utils/client";
 import type {
   CancelDocumentRequestParams,
   CancelDocumentRequestQuery,
@@ -55,14 +56,10 @@ import { getSignatureParams } from "src/utils/signature";
 import { MyInvoisError } from "src/utils/error-handler";
 
 export async function getRecentDocuments(
-  query: GetRecentDocumentsRequestQuery
+  query: GetRecentDocumentsRequestQuery,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const { taxpayerTIN: taxpayerTIN, ...params } = query;
   try {
@@ -81,14 +78,10 @@ export async function getRecentDocuments(
 
 export async function getDocumentDetails(
   params: GetDocumentDetailsRequestParams,
-  query: GetDocumentDetailsRequestQuery
+  query: GetDocumentDetailsRequestQuery,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const documentId = params.id;
   const taxpayerTIN = query.taxpayerTIN;
@@ -109,14 +102,10 @@ export async function getDocumentDetails(
 
 export async function getDocument(
   params: GetDocumentRequestParams,
-  query: GetDocumentRequestQuery
+  query: GetDocumentRequestQuery,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const documentId = params.id;
   const taxpayerTIN = query.taxpayerTIN;
@@ -135,13 +124,11 @@ export async function getDocument(
   }
 }
 
-export async function searchDocuments(query: SearchDocumentsRequestQuery) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+export async function searchDocuments(
+  query: SearchDocumentsRequestQuery,
+  headers: Headers
+) {
+  const client = createClient(headers);
 
   const { taxpayerTIN, ...params } = query;
   try {
@@ -165,14 +152,10 @@ export async function searchDocuments(query: SearchDocumentsRequestQuery) {
 
 export async function rejectDocument(
   params: RejectDocumentRequestParams,
-  query: RejectDocumentRequestQuery
+  query: RejectDocumentRequestQuery,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const { id } = params;
   const { reason, taxpayerTIN } = query;
@@ -196,14 +179,10 @@ export async function rejectDocument(
 
 export async function cancelDocument(
   params: CancelDocumentRequestParams,
-  query: CancelDocumentRequestQuery
+  query: CancelDocumentRequestQuery,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const { id } = params;
   const taxpayerTIN = query.taxpayerTIN;
@@ -229,14 +208,10 @@ export async function cancelDocument(
 
 export async function submitInvoices(
   query: SubmitInvoiceDocumentsQuery,
-  body: SubmitInvoiceDocumentsBody
+  body: SubmitInvoiceDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;
@@ -273,14 +248,10 @@ export async function submitInvoices(
 
 export async function submitCreditNotes(
   query: SubmitCreditNoteDocumentsQuery,
-  body: SubmitCreditNoteDocumentsBody
+  body: SubmitCreditNoteDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;
@@ -318,14 +289,10 @@ export async function submitCreditNotes(
 
 export async function submitDebitNotes(
   query: SubmitDebitNoteDocumentsQuery,
-  body: SubmitDebitNoteDocumentsBody
+  body: SubmitDebitNoteDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;
@@ -365,14 +332,10 @@ export async function submitDebitNotes(
 
 export async function submitRefundNotes(
   query: SubmitRefundNoteDocumentsQuery,
-  body: SubmitRefundNoteDocumentsBody
+  body: SubmitRefundNoteDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;
@@ -411,14 +374,10 @@ export async function submitRefundNotes(
 
 export async function submitSelfBilledInvoices(
   query: SubmitSelfBilledInvoiceDocumentsQuery,
-  body: SubmitSelfBilledInvoiceDocumentsBody
+  body: SubmitSelfBilledInvoiceDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;
@@ -457,14 +416,10 @@ export async function submitSelfBilledInvoices(
 
 export async function submitSelfBilledCreditNotes(
   query: SubmitSelfBilledCreditNoteDocumentsQuery,
-  body: SubmitSelfBilledCreditNoteDocumentsBody
+  body: SubmitSelfBilledCreditNoteDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;
@@ -503,14 +458,10 @@ export async function submitSelfBilledCreditNotes(
 
 export async function submitSelfBilledDebitNotes(
   query: SubmitSelfBilledDebitNoteDocumentsQuery,
-  body: SubmitSelfBilledDebitNoteDocumentsBody
+  body: SubmitSelfBilledDebitNoteDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;
@@ -549,14 +500,10 @@ export async function submitSelfBilledDebitNotes(
 
 export async function submitSelfBilledRefundNotes(
   query: SubmitSelfBilledRefundNoteDocumentsQuery,
-  body: SubmitSelfBilledRefundNoteDocumentsBody
+  body: SubmitSelfBilledRefundNoteDocumentsBody,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const taxpayerTIN = query.taxpayerTIN;
   const _documents = body.documents;

--- a/src/routes/submissions/submissions.controller.ts
+++ b/src/routes/submissions/submissions.controller.ts
@@ -15,8 +15,8 @@ export const submissionsController = (app: Elysia) => {
       })
       .get(
         "/:id",
-        async ({ params, query }) => {
-          return await getSubmissionDetails(params, query);
+        async ({ params, query, request }) => {
+          return await getSubmissionDetails(params, query, request.headers);
         },
         {
           detail: {

--- a/src/routes/submissions/submissions.service.ts
+++ b/src/routes/submissions/submissions.service.ts
@@ -1,6 +1,7 @@
 import { CONFIG } from "src/config";
 import { redisInstance } from "src/redis";
 import { MyInvoisClient } from "myinvois-client";
+import { createClient } from "src/utils/client";
 import type {
   GetSubmissionRequestParams,
   GetSubmissionRequestQuery,
@@ -16,14 +17,10 @@ import type {
  */
 export async function getSubmissionDetails(
   params: GetSubmissionRequestParams,
-  query: GetSubmissionRequestQuery
+  query: GetSubmissionRequestQuery,
+  headers: Headers
 ) {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const submissionId = params.id; // Assuming the submission ID is a path parameter named 'id'
   const taxpayerTIN = query.taxpayerTIN;

--- a/src/routes/taxpayers/taxpayers.controller.ts
+++ b/src/routes/taxpayers/taxpayers.controller.ts
@@ -20,8 +20,8 @@ export const taxpayersController = (app: Elysia) => {
       })
       .get(
         "/search/tin",
-        async ({ query }) => {
-          return await searchTaxpayerTINByParams(query);
+        async ({ query, request }) => {
+          return await searchTaxpayerTINByParams(query, request.headers);
         },
         {
           detail: {
@@ -34,8 +34,12 @@ export const taxpayersController = (app: Elysia) => {
       )
       .get(
         "/qrcode/:id",
-        async ({ params, query }) => {
-          return await getTaxpayerInfoByQRCodeFromClient(params, query);
+        async ({ params, query, request }) => {
+          return await getTaxpayerInfoByQRCodeFromClient(
+            params,
+            query,
+            request.headers
+          );
         },
         {
           detail: {

--- a/src/routes/taxpayers/taxpayers.service.ts
+++ b/src/routes/taxpayers/taxpayers.service.ts
@@ -6,6 +6,7 @@ import {
 } from "myinvois-client";
 import { CONFIG } from "src/config";
 import { redisInstance } from "src/redis";
+import { createClient } from "src/utils/client";
 import type {
   GetTaxpayerInfoByQRCodeRequestParams,
   GetTaxpayerInfoByQRCodeRequestQuery,
@@ -20,14 +21,10 @@ import type {
  * @throws Error if Client ID, Client Secret are not configured, or if the environment is invalid.
  */
 export const searchTaxpayerTINByParams = async (
-  query: SearchTaxpayerTINRequestQuery
+  query: SearchTaxpayerTINRequestQuery,
+  headers: Headers
 ) => {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   const params: SearchTaxpayerTINRequestParams = {
     idType: query.idType as TaxpayerIdType, // Ensure schema aligns with this type
@@ -56,14 +53,10 @@ export const searchTaxpayerTINByParams = async (
  */
 export const getTaxpayerInfoByQRCodeFromClient = async (
   params: GetTaxpayerInfoByQRCodeRequestParams,
-  query: GetTaxpayerInfoByQRCodeRequestQuery
+  query: GetTaxpayerInfoByQRCodeRequestQuery,
+  headers: Headers
 ) => {
-  const client = new MyInvoisClient(
-    CONFIG.clientId,
-    CONFIG.clientSecret,
-    CONFIG.env,
-    redisInstance
-  );
+  const client = createClient(headers);
 
   try {
     const result = await client.taxpayer.getTaxpayerInfoByQRCode(

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -1,0 +1,9 @@
+import { MyInvoisClient } from 'myinvois-client';
+import { CONFIG } from '../config';
+import { redisInstance } from '../redis';
+import { resolveCredentials } from './credentials';
+
+export function createClient(headers: Headers): MyInvoisClient {
+  const creds = resolveCredentials(headers, { clientId: CONFIG.clientId, clientSecret: CONFIG.clientSecret });
+  return new MyInvoisClient(creds.clientId, creds.clientSecret, CONFIG.env, redisInstance);
+}

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -1,0 +1,11 @@
+export function resolveCredentials(headers: Headers, fallback: {clientId: string; clientSecret: string}) {
+  const headerClientId = headers.get('x-client-id');
+  const headerClientSecret = headers.get('x-client-secret');
+  if ((headerClientId && !headerClientSecret) || (!headerClientId && headerClientSecret)) {
+    throw new Error('Both X-CLIENT-ID and X-CLIENT-SECRET must be provided together');
+  }
+  return {
+    clientId: headerClientId ?? fallback.clientId,
+    clientSecret: headerClientSecret ?? fallback.clientSecret,
+  };
+}


### PR DESCRIPTION
## Summary
- allow overriding client credentials via `X-CLIENT-ID` and `X-CLIENT-SECRET`
- expose `/health` endpoint
- document new headers and endpoint in README
- update Swagger docs for new security schemes

## Testing
- `bun run lint` *(fails: jiti 403)*
- `bun install` *(fails: network 403)*

------
https://chatgpt.com/codex/tasks/task_e_6865e01a9e6c83309a7490925d00a115